### PR TITLE
Fix typo, documentation link changed to point to jqueryvalidation.org instead of validation.bassistance.de

### DIFF
--- a/entries/maxlength-method.xml
+++ b/entries/maxlength-method.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <entry name="maxlength" type="method" return="Boolean">
 	<title>maxlength method</title>
-	<desc>Makes the element require a given maxmimum length.</desc>
+	<desc>Makes the element require a given maximum length.</desc>
 	<longdesc>
 		Return false if the element is
 		<ul>

--- a/pages/index.html
+++ b/pages/index.html
@@ -16,7 +16,7 @@
 <a title="zip-Archive with source code, minified and packed version, demos and examples" href="http://jquery.bassistance.de/validate/jquery-validation-1.11.1.zip">Download</a>
 <a href="http://jquery.bassistance.de/validate/changelog.txt">Changelog</a>
 <a href="http://jquery.bassistance.de/validate/demo/">Demos</a>
-<a href="http://validation.bassistance.de/documentation/">Documentation</a>
+<a href="http://jqueryvalidation.org/documentation/">Documentation</a>
 <a href="https://github.com/jzaefferer/jquery-validation">GitHub Repository</a>
 <a href="https://github.com/jzaefferer/jquery-validation/tree/1.11.1">GitHub 1.11.1 Tag</a>
 


### PR DESCRIPTION
This does 2 things:
1.  Fixes a typo in the maxlength-method documentation
2.  Changes the documentation link in the root of the site to point to http://jqueryvalidation.org/documentation/ instead of http://validation.bassistance.de/documentation/ (by the way the same result could equally be achieved by turning the link into a relative link instead of a fully qualified one)
