### PR TITLE
Update remote-method.xml

### DIFF
--- a/entries/remote-method.xml
+++ b/entries/remote-method.xml
@@ -3,7 +3,7 @@
 	<title>remote method</title>
 	<desc>Requests a resource to check the element for validity.</desc>
 	<longdesc>
-		The serverside resource is called via jQuery.ajax (XMLHttpRequest) and gets a key/value pair corresponding to the name of the validated element and its value as a GET parameter. The response is evaluated as JSON and must be <code>true</code> for valid elements, and can be any <code>false</code>, <code>undefined</code> or <code>null</code> for invalid elements, using the default message; or a string, eg. <code>"That name is already taken, try peter123 instead"</code> to display as the error message.
+		The serverside resource is called via jQuery.ajax (XMLHttpRequest) and gets a key/value pair corresponding to the name of the validated element and its value as a GET parameter. The serverside response must be a JSON string that must be <code>"true"</code> for valid elements, and can be <code>"false"</code>, <code>undefined</code>, or <code>null</code> for invalid elements, using the default error message.  If the serverside response is a string, eg. <code>"That name is already taken, try peter123 instead"</code>, this string will be displayed as a custom error message in place of the default.
 
 		<p>For more examples, take a look the <a href="http://jquery.bassistance.de/validate/demo/marketo">marketo demo</a> and the <a href="http://jquery.bassistance.de/validate/demo/milk">milk demo</a>.</p>
 	</longdesc>


### PR DESCRIPTION
There is a lot of confusion surrounding proper usage of the `remote` method based on the number of Stack Overflow questions about it.  I am proposing this slight change to help clarify.

Proposed:

> The serverside response must be a JSON string that must be `"true"` for valid elements, and can be `"false"`, `undefined`, or `null` for invalid elements, using the default error message.  If the serverside response is a string, eg. `"That name is already taken, try peter123 instead"`, this string will be displayed as a custom error message in place of the default.