### PR TITLE
Entries: Promote jQuery.validator.methods property as public api

### DIFF
--- a/entries/email-method.xml
+++ b/entries/email-method.xml
@@ -5,6 +5,7 @@
 	<longdesc>
 		Return true if the value is a valid email address.
 		<p>Works with text inputs.</p>
+		<p>In case you need a custom email pattern use the <a href="/jQuery.validator.methods/">$.validator.methods property</a>.</p>
 	</longdesc>
 	<example>
 		<desc>Makes "field" required and an email address.</desc>

--- a/entries/jQuery.validator.methods.xml
+++ b/entries/jQuery.validator.methods.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="../entries2html.xsl" ?>
+<entry type="method" name="jQuery.validator.methods" returns="Object">
+	<title>jQuery.validator.methods</title>
+	<desc>Object holding all validation methods known to the validator. This can be accessed to override individual methods, while keeping the default messages.</desc>
+	<example>
+		<desc>Sets a custom email pattern for the built-in email validation rule.</desc>
+		<code><![CDATA[
+$.validator.methods.email = function( value, element ) {
+  return this.optional( element ) || /[a-z]+@[a-z]+\.[a-z]+/.test( value );
+}
+]]></code>
+	</example>
+	<category slug="validator"/>
+</entry>

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -133,6 +133,8 @@ Some more methods are provided as add-ons, and are currently included in additio
 
 You can find the [source code for all additional methods in the GitHub repository](https://github.com/jzaefferer/jquery-validation/tree/master/src/additional).
 
+It is possible to re-define the implementation of the built-in rules using the [`$.validator.methods` property](/jQuery.validator.methods/)
+
 # [General Guidelines](/reference)
 
 The General Guidelines section provides detailed discussion of the design and ideas behind the plugin, explaining why certain things are as they are. It covers the features in more detail than the API documentation, which just briefly explains the various methods and options available.


### PR DESCRIPTION
Includes a example which shows how to make built-in email validation use
a custom email regular expression pattern.