### PR TITLE
Entries: add missing argument `event` to `submitHandler` docs

### DIFF
--- a/entries/validate.xml
+++ b/entries/validate.xml
@@ -48,6 +48,9 @@
 				<property name="form" type="Element">
 					<desc>The form currently being validated, as a DOMElement.</desc>
 				</property>
+				<property name="event" type="Event">
+					<desc>The submit event instance.</desc>
+				</property>
 				<type name="Function"/>
 			</property>
 			<property name="invalidHandler">


### PR DESCRIPTION
Added in jzaefferer/jquery-validation#233 but not document until now.