### PR TITLE
Update extension-method.xml

### DIFF
--- a/entries/extension-method.xml
+++ b/entries/extension-method.xml
@@ -5,6 +5,7 @@
 	<longdesc>
 		Returns true if the value ends with one of the specified file extensions. If nothing is specified, only images are allowed (png, jpeg, gif).
 		<p>Works with text inputs.</p>
+		<p>Part of the additional-methods.js file</p>
 	</longdesc>
 	<signature>
 		<argument name="extension" type="String" optional="true">


### PR DESCRIPTION
Many questions on StackOverflow are triggered by errors caused by users not knowing that this method is part of the Additional Methods file.  This is a matter of fact and should be included in the documentation.