### PR TITLE
Update accept-method.xml

### DIFF
--- a/entries/accept-method.xml
+++ b/entries/accept-method.xml
@@ -10,7 +10,7 @@
 		<p>You can specify multiple mime-types by separating them with a comma, e.g. "image/x-eps,application/pdf".</p>
 
 		<p>Works with type="file" inputs.</p>
-
+		<p>Part of the additional-methods.js file</p>
 		<p>Note: This method used to look at just the filename, specifically the file extension. That behaviour is now available as the "extension" method inside src/additional/extension.js.</p>
 	</longdesc>
 	<signature>


### PR DESCRIPTION
Many questions on StackOverflow are triggered by errors caused by users not knowing that this method is part of the Additional Methods file.  This is a matter of fact and should be included in the documentation.