### PR TITLE
Update creditcard-method.xml

### DIFF
--- a/entries/creditcard-method.xml
+++ b/entries/creditcard-method.xml
@@ -5,6 +5,7 @@
 	<longdesc>
 		Return true if the value is a valid credit card number.
 		<p>Works with text inputs.</p>
+		<p>Part of the additional-methods.js file</p>
 		<p>Note: The algorithm used can't verify the validity of the number - it is just an integrity check. As with any other clientside validation, you have to implement the same or better validation on the serverside.</p>
 	</longdesc>
 	<example>


### PR DESCRIPTION
Many questions on StackOverflow are triggered by errors caused by users not knowing that this method is part of the Additional Methods file.  This is a matter of fact and should be included in the documentation.