### PR TITLE
Update phoneUS-method.xml

### DIFF
--- a/entries/phoneUS-method.xml
+++ b/entries/phoneUS-method.xml
@@ -4,6 +4,7 @@
 	<desc>Validate for valid US phone number.</desc>
 	<longdesc>
 		Works with text inputs.
+		<p>Part of the additional-methods.js file</p>
 	</longdesc>
 	<example>
 		<desc>Makes "field" required and a US phone number.</desc>


### PR DESCRIPTION
Many questions on StackOverflow are triggered by errors caused by users not knowing that this method is part of the Additional Methods file.  This is a matter of fact and should be included in the documentation.