### PR TITLE
Update require_from_group-method.xml

### DIFF
--- a/entries/require_from_group-method.xml
+++ b/entries/require_from_group-method.xml
@@ -8,6 +8,7 @@
 		group. Then apply this rule to all the fields within the group.
 		The form then cannot be submitted until at least the minimum number have
 		been completed.
+		<p>Part of the additional-methods.js file</p>
 	</longdesc>
 	<example>
 		<desc>Within a group of three phone numbers, ensure at least one is complete.</desc>


### PR DESCRIPTION
Many questions on StackOverflow are triggered by errors caused by users not knowing that this method is part of the Additional Methods file.  This is a matter of fact and should be included in the documentation.