### PR TITLE
Document customElements option

### DIFF
--- a/entries/validate.xml
+++ b/entries/validate.xml
@@ -538,6 +538,19 @@
 				</desc>
 				<type name="Boolean"/>
 			</property>
+			<property name="customElements" default="[]">
+				<desc>
+				    By default, only the following elements are validatable input, select, textarea, [contenteditable]
+					Register additional elements. Main use case is for validating web components.
+					<p><strong>Example</strong>: Register &lt;my-custom-element&gt; to be validatable as well.</p>
+					<pre><code>
+					$("#myform").validate({
+						customElements: ["my-custom-element"]
+					});
+					</code></pre>
+				</desc>
+				<type name="Array"/>
+			</property>
 		</argument>
 	</signature>
 	<category slug="plugin"/>

--- a/entries/validate.xml
+++ b/entries/validate.xml
@@ -540,8 +540,8 @@
 			</property>
 			<property name="customElements" default="[]">
 				<desc>
-				    By default, only the following elements are validatable input, select, textarea, [contenteditable]
-					Register additional elements. Main use case is for validating web components.
+				    By default, only the following elements are validatable: input, select, textarea and [contenteditable]
+					Use this to register your additional/custom elements, for example web components.
 					<p><strong>Example</strong>: Register &lt;my-custom-element&gt; to be validatable as well.</p>
 					<pre><code>
 					$("#myform").validate({


### PR DESCRIPTION
Documented the new option `customElements` merged with https://github.com/jquery-validation/jquery-validation/pull/2493

Side note:
It might make sense to provide a docker-compose.yaml in this repository for an easier setup of the local wordpress instance.
I used this as a base which could be further improved to straightly provide the theme (git submodule?!) and the plugins (check in zip files in repository):
```
services:
  mariadb:
    image: mariadb:lts
    environment:
      MYSQL_ROOT_PASSWORD: rootpassword
      MYSQL_DATABASE: wordpress
      MYSQL_USER: wordpress
      MYSQL_PASSWORD: jqueryvalidation
    healthcheck:
      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
      start_period: 10s
      interval: 10s
      timeout: 5s
      retries: 3
  wordpress:
    image: wordpress:4.7
    ports:
      - 8080:80
    environment:
      WORDPRESS_DB_HOST: mariadb:3306
      WORDPRESS_DB_NAME: wordpress
      WORDPRESS_DB_USER: wordpress
      WORDPRESS_DB_PASSWORD: jqueryvalidation
    depends_on:
      mariadb:
        condition: service_healthy
```