### PR TITLE
Adding the possibility to use Dev Container for building

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-in-docker
+{
+	"name": "jQuery Validation Documentation",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "20.10",
+			"enableNonRootDocker": "true",
+			"moby": "true"
+		},
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"forwardPorts": [8080],
+	"postCreateCommand": ".devcontainer/postCreateCommand.sh"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#prepare wordpress installation
+cp config-sample-docker.json config.json
+mkdir -p wordpress/wp-content
+wget https://downloads.wordpress.org/theme/twentytwelve.4.3.zip -O /tmp/twentytwelve.4.3.zip && unzip /tmp/twentytwelve.4.3.zip -d wordpress/wp-content/themes && rm -f /tmp/twentytwelve.4.3.zip
+sudo git clone https://github.com/jzaefferer/validation-theme wordpress/wp-content/themes/validation-theme
+mkdir -p wordpress/wp-content/plugins/gilded-wordpress && wget https://raw.githubusercontent.com/scottgonzalez/gilded-wordpress/v1.0.0/gilded-wordpress.php -O wordpress/wp-content/plugins/gilded-wordpress/gilded-wordpress.php
+mkdir -p wordpress/wp-content/plugins/jquery-static-index && wget https://raw.githubusercontent.com/jquery/jquery-wp-content/v4.0.1/plugins/jquery-static-index.php -O wordpress/wp-content/plugins/jquery-static-index/jquery-static-index.php
+
+# setup additional dependencies here (would features be a better place?)
+sudo apt-get update && sudo apt-get install libxml2-utils libxslt1.1 xsltproc -y
+
+# setup grunt globally
+npm install -g grunt-cli
+
+# install local dependencies
+npm install

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 config.json
+wordpress

--- a/README.md
+++ b/README.md
@@ -33,3 +33,27 @@ In this repo:
 ### Deploy
 
 `grunt deploy`
+
+## Building with Dev Containers
+The Dev Container is a DIND (docker-in-docker) which comes with all the requirements pre-installed. Start the WordPress instance with: 
+
+`docker-compose up` and visit `http://localhost:8080`
+
+### Requirements
+* Open this repository in Visual Studio Code with Dev Containers extension installed (https://code.visualstudio.com/docs/devcontainers/containers)
+  
+### Installation
+* Setup WordPress with:
+  * **Site Title**: Form validation with jQuery
+  * **Username**: admin
+  * **Password**: secret
+  * *tick the checkbox 'Confirm use of weak password'*
+  * **Your Email**: &lt;enter a valid email address&gt;
+* Activate theme 'jQuery Validation Plugin WordPress Theme' (Appeareance)
+* Activate plugin 'Gilded WordPress XML-RPC extensions' (Plugins)
+* Activate plugin 'jQuery Static Index' (Plugins)
+
+
+### Deploy
+
+`grunt deploy`

--- a/config-sample-docker.json
+++ b/config-sample-docker.json
@@ -1,0 +1,9 @@
+{
+	"url": "http://localhost:8080",
+	"username": "admin",
+	"password": "secret",
+	"basicAuth": {
+		"username": "basic-auth-admin",
+		"password": "basic-auth-secret"
+	}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+services:
+  mariadb:
+    image: mariadb:lts
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: jqueryvalidation
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  wordpress:
+    image: wordpress:4.7
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: mariadb:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: jqueryvalidation
+    volumes:
+      - ./wordpress/wp-content:/var/www/html/wp-content
+    depends_on:
+      mariadb:
+        condition: service_healthy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,412 +1,715 @@
 {
   "name": "jqueryvalidation-content",
   "version": "1.0.0",
-  "lockfileVersion": 1,
-  "dependencies": {
-    "abbrev": {
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jqueryvalidation-content",
+      "version": "1.0.0",
+      "dependencies": {
+        "grunt": "0.4.5",
+        "grunt-jquery-content": "2.0.0"
+      }
+    },
+    "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
       "dependencies": {
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
-        }
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
       }
     },
-    "async": {
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "cheerio": {
+    "node_modules/cheerio": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.17.0.tgz",
-      "integrity": "sha1-+lrkLMYBIRM9KW0LRtmDIV9yaOo=",
+      "integrity": "sha512-pakQLw14btS8T4+Q3dgFbe7x447hjsQeEhMJ2kHg8YrOLSmKS0xGl9REnz/eic7dsxS0S9kMRbZcsqrlMAS0dQ==",
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
+        "CSSselect": "~0.4.0",
+        "dom-serializer": "~0.0.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.7.2",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "coffee-script": {
+    "node_modules/cheerio/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/coffee-script": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ="
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "colors": {
+    "node_modules/colors": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "CSSselect": {
+    "node_modules/CSSselect": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-      "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI="
+      "integrity": "sha512-r4HWARRbQ6enGbdPCrl3bNybORIcU0AcBLTyaxcWNTRd6EH2/w9RInHkUbUhwehrBFN1KQz+yFulhyIH31ZXAw==",
+      "deprecated": "the module is now available as 'css-select'",
+      "dependencies": {
+        "CSSwhat": "0.4",
+        "domutils": "1.4"
+      }
     },
-    "CSSwhat": {
+    "node_modules/CSSwhat": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
+      "integrity": "sha512-bU5cYG02crjQGDN6wm8USThp/sr/MUulMTrVA1CENSBhv3B+mlJfYDP1em/wJlMT0aYcWso0cuT9NXW74yPfog==",
+      "deprecated": "the module is now available as 'css-what'",
+      "engines": {
+        "node": "*"
+      }
     },
-    "dateformat": {
+    "node_modules/dateformat": {
       "version": "1.0.2-1.2.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk="
+      "integrity": "sha512-AXvW8g7tO4ilk5HgOWeDmPi/ZPaCnMJ+9Cg1I3p19w6mcvAAXBuuGEXAxybC+Djj1PSZUiHUcyoYu7WneCX8gQ==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "dom-serializer": {
+    "node_modules/dom-serializer": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
-      "integrity": "sha1-lYmCfx4y0iw3yCmtq9WbMkevjq8=",
+      "integrity": "sha512-evvizoLtT5uMpDT3iKRAx1NmTCk2ZdOD7ATqmL27QJkCv8XQmGKv/eFuvAjHhySNBACREAcXGBqozYhV1dOdag==",
       "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        }
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       }
     },
-    "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    "node_modules/domelementtype": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+      "integrity": "sha512-zEvAAsFY0DeHkrqWBRkSsmgaE7yADgpez40JUFjISb+uzSinl2F6QbG4lMEBE4P06gCGF6VnsykmbNgu7ZIHzA=="
     },
-    "domhandler": {
+    "node_modules/domhandler": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
-      "integrity": "sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I="
+      "integrity": "sha512-MFFBQFGkyTuNe3vL9WEw9JdlCwIoBYpOGESLeZAvc/jClYNsOl6P1KzevJbWg76GovdEycfR7/2/Ra7NnqtMKw==",
+      "dependencies": {
+        "domelementtype": "1"
+      }
     },
-    "domutils": {
+    "node_modules/domutils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8="
+      "integrity": "sha512-ZkVgS/PpxjyJMb+S2iVHHEZjVnOUtjGp0/zstqKGTE9lrZtNHlNQmLwP/lhLMEApYbzc08BKMx9IFpKhaSbW1w==",
+      "dependencies": {
+        "domelementtype": "1"
+      }
     },
-    "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    "node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
-    "esprima": {
+    "node_modules/esprima": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "eventemitter2": {
+    "node_modules/eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
     },
-    "exit": {
+    "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "findup-sync": {
+    "node_modules/findup-sync": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "integrity": "sha512-yjftfYnF4ThYEvKEV/kEFR15dmtyXTAh3vQnzpJUoc7Naj5y1P0Ck7Zs1+Vroa00E3KT3IYsk756S+8WA5dNLw==",
       "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0="
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0="
-        }
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
-    "getobject": {
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/getobject": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
+      "integrity": "sha512-hIGEBfnHcZpWkXPsAVeVmpYDvfy/matVl03yOY91FPmnpCC12Lm5izNxCjO3lHAeO6uaTwMxu7g450Siknlhig==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "gilded-wordpress": {
+    "node_modules/gilded-wordpress": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gilded-wordpress/-/gilded-wordpress-1.0.0.tgz",
-      "integrity": "sha1-xqLn1wetWX2pMQdeAcL+iBtttaA=",
+      "integrity": "sha512-rWfEd3P6V/Q9LhQQutaDCG26Fnx/46PiEvRQ20x2jbwDZ1xrowQzAkoghjMpboYfizwCcxPM774367BqkL5AeA==",
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "glob": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-          "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac="
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg="
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20="
-        }
+        "async": "~0.9.0",
+        "glob": "~4.0.6",
+        "wordpress": "~1.0.0"
       }
     },
-    "glob": {
+    "node_modules/gilded-wordpress/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw=="
+    },
+    "node_modules/gilded-wordpress/node_modules/glob": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+      "integrity": "sha512-D0H1thJnOVgI0zRV3H/Vmb9HWmDgGTTR7PeT8Lk0ri2kMmfK3oKQBolfqJuRpBVpTx5Q5PKGl9hdQEQNTXJI7Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "graceful-fs": "^3.0.2",
+        "inherits": "2",
+        "minimatch": "^1.0.0",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gilded-wordpress/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/gilded-wordpress/node_modules/minimatch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+      "integrity": "sha512-Ejh5Odk/uFXAj5nf/NSXk0UamqcGAfOdHI7nY0zvCHyn4f3nKLFoUTp+lYxDxSih/40uW8lpwDplOWHdWkQXWA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
       "version": "3.1.21",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
-        }
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "grunt": {
+    "node_modules/grunt": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A="
+      "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "grunt-check-modules": {
+    "node_modules/grunt-check-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-check-modules/-/grunt-check-modules-1.0.0.tgz",
-      "integrity": "sha1-Y/9erkYTF5tKifaozTcfekAfd4I="
+      "integrity": "sha512-+wRpqAMa7iqted+rTj+6n4EN1vBd2GqOvSMU8YZTiFizxAgZQ5CmV/+nwGfjT5ySQaX3enGqT8r9diLEX5aCEg==",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "peerDependencies": {
+        "grunt": "0.4.x"
+      }
     },
-    "grunt-jquery-content": {
+    "node_modules/grunt-jquery-content": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-jquery-content/-/grunt-jquery-content-2.0.0.tgz",
-      "integrity": "sha1-jVFDOs0z/n7VL9956gAxwCRSwII=",
+      "integrity": "sha512-3yhwokTAI4p1uoDyjLqmRccOrWBeJlLgDcw3kUc6jyovrTFF3PEPdNTbTzNrdoq6LP29Asz+YJyE/6jwK0Et/Q==",
       "dependencies": {
-        "async": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-          "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
-        },
-        "which": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz",
-          "integrity": "sha1-VjDWgZ3aaS8UZEYueVbLQsCEJzk="
-        }
+        "async": "0.9.0",
+        "cheerio": "0.17.0",
+        "grunt-check-modules": "1.0.0",
+        "grunt-wordpress": "2.1.0",
+        "he": "0.5.0",
+        "highlight.js": "7.3.0",
+        "marked": "0.3.2",
+        "rimraf": "2.2.8",
+        "spawnback": "1.0.0",
+        "which": "1.0.5"
       }
     },
-    "grunt-legacy-log": {
+    "node_modules/grunt-jquery-content/node_modules/async": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+      "integrity": "sha512-XQJ3MipmCHAIBBMFfu2jaSetneOrXbSyyqeU3Nod867oNOpS+i9FEms5PWgjMxSgBybRf2IVVLtr1YfrDO+okg=="
+    },
+    "node_modules/grunt-jquery-content/node_modules/which": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz",
+      "integrity": "sha512-p82w9e3628Y1sCI41PbzZb5Qbacst2Yt/gE4mtqrNXv65SmwNbAcQvS4VkehtqmclAcOh36tgQiwhg6fKvkyDA==",
+      "bin": {
+        "which": "bin/which"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "integrity": "sha512-qYs/uM0ImdzwIXLhS4O5WLV5soAM+PEqqHI/hzSxlo450ERSccEhnXqoeDA9ZozOdaWuYnzTOTwRcVRogleMxg==",
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
-        }
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-legacy-log-utils": {
+    "node_modules/grunt-legacy-log-utils": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "integrity": "sha512-D0vbUX00TFYCKNZtcZzemMpwT8TR/FdRs1pmfiBw6qnUw80PfsjV+lhIozY/3eJ3PSG2zj89wd2mH/7f4tNAlw==",
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
-        }
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-legacy-util": {
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs="
-    },
-    "grunt-wordpress": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-wordpress/-/grunt-wordpress-2.1.0.tgz",
-      "integrity": "sha1-ty0EttVbQdFP/Yrq8W0ibFk9vl0="
-    },
-    "he": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
-    },
-    "highlight.js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-7.3.0.tgz",
-      "integrity": "sha1-bF8PZOcHj2ZAK82/yJEQw/0bqZ8="
-    },
-    "hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
-    },
-    "htmlparser2": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-      "integrity": "sha1-amTHdjfAjG8w7CqBV6UzM758sF4=",
+      "integrity": "sha512-cXPbfF8aM+pvveQeN1K872D5fRm30xfJWZiS63Y8W8oyIPLClCsmI8bW96Txqzac9cyL4lRqEBhbhJ3n5EzUUQ==",
       "dependencies": {
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8="
-        },
-        "entities": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-        }
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "iconv-lite": {
+    "node_modules/grunt-wordpress": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-wordpress/-/grunt-wordpress-2.1.0.tgz",
+      "integrity": "sha512-46PZNzM/6UyZOdqsro9dvNYHoq5/ZKflzim6WnCRszqVxbF2rAmUHsX1aAhAwvjQgg7iznWv2TOHqPIvqNvvDQ==",
+      "dependencies": {
+        "gilded-wordpress": "1.0.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
+      "integrity": "sha512-DoufbNNOFzwRPy8uecq+j+VCPQ+JyDelHTmSgygrA5TsR8Cbw4Qcir5sGtWiusB4BdT89nmlaVDhSJOqC/33vw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-7.3.0.tgz",
+      "integrity": "sha512-OHxLFYMoq1D56t6EtTeeB9X8Or+WJMEopds7ZOXzCnNfkjwRWK2QlNhxFVCpX7MT6wGvka6+UD/aDu5MIzHnCw==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+      "integrity": "sha512-XdyuCBH3/tTuRTCMFolbj5stKZek8FK7KVXm+aHYivHmXVo18jINvc2jR5zgFkp//z2KWl5vppTJ4DWhltYruA==",
+      "dependencies": {
+        "domelementtype": "1",
+        "domhandler": "2.2",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ=="
+    },
+    "node_modules/iconv-lite": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    "node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA=="
     },
-    "isarray": {
+    "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g="
+      "integrity": "sha512-VEKcIksckDBUhg2JS874xVouiPkywVUh4yyUmLCDe1Zg3bCd6M+F1eGPenPeHLc2XC8pp9G8bsuofK0NeEqRkA==",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "0.9.2",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha512-LVbt/rjK62gSbhehDVKL0vlaime4Y1IBixL+bKeNfoY4L2zab/jGrxU6Ka05tMA/zBxkTk5t3ivtphdyYupczw==",
+      "engines": [
+        "node",
+        "rhino"
+      ]
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
     },
-    "marked": {
+    "node_modules/marked": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz",
-      "integrity": "sha1-AV2xWIZEOPJKZL3WGgQotBhwbQk="
+      "integrity": "sha512-Wvq6b3iV2F03cdF0FdXNNQSGAWAcrSW/RjHeMWyHr/zR8MWtmTKNEkgA8VfPdpu8EiGuFgxCPgVxJgBZoPCpAQ==",
+      "bin": {
+        "marked": "bin/marked"
+      }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo="
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
-    "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
-    },
-    "nopt": {
+    "node_modules/nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4="
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
     },
-    "rimraf": {
+    "node_modules/readable-stream/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/rimraf": {
       "version": "2.2.8",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "bin": {
+        "rimraf": "bin.js"
+      }
     },
-    "sax": {
+    "node_modules/sax": {
       "version": "0.4.3",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-0.4.3.tgz",
-      "integrity": "sha1-cA46NOsueSzjgHkccSgPNzGWXdw="
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.3.tgz",
+      "integrity": "sha512-WvnHpLKMuEsJFV3LXuvxKY4sLdKev2tIeUxn+ljlQAhpx4ZEmJOW+nEa0uERX7XvfxoimvXvEqeo94p2jXoL6g=="
     },
-    "sigmund": {
+    "node_modules/sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
     },
-    "spawnback": {
+    "node_modules/spawnback": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawnback/-/spawnback-1.0.0.tgz",
-      "integrity": "sha1-9zZi9+VNlTZ+ynTWQmxnfdfqaG8="
+      "integrity": "sha512-xcoszq8qrEKpLpsp/1r+e+wkblvzV/h9tUxipb7aqB0WYWTBo6ZQD+SlfzkaTQ5XrgPwqHCCU9UmMdM6OifF2w=="
     },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
-    "underscore": {
+    "node_modules/underscore": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
     },
-    "underscore.string": {
+    "node_modules/underscore.string": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
+      "integrity": "sha512-3FVmhXqelrj6gfgp3Bn6tOavJvW0dNH2T+heTD38JRxIrAbiuzbqjknszoOYj3DyFB1nWiLj208Qt2no/L4cIA==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "which": {
+    "node_modules/which": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "bin": {
+        "which": "bin/which"
+      }
     },
-    "wordpress": {
+    "node_modules/wordpress": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordpress/-/wordpress-1.0.0.tgz",
-      "integrity": "sha1-m+FQ5pObYUnVw0F017UIeOK7s88="
+      "integrity": "sha512-zlTdsP6nd06NRFAiWzQFNeWOZwkYE7tunB3vDbpUS5gGrhoAYMq2lQmOqjPJxsCJpvUSh1gC0vQTZhNg3TioZA==",
+      "dependencies": {
+        "xmlrpc": "1.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "xmlbuilder": {
+    "node_modules/xmlbuilder": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.3.1.tgz",
-      "integrity": "sha1-XtTCK0YiwkN/r4Pk8jbyPWu/JkE="
+      "integrity": "sha512-TPEOiazMKB2h4pzQiTvmhg0W/VARha8t2BW0/CX6ayjF4MtPp54PoIiktXII6ryX/nGsetexRBL+X6sP/D72hQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
-    "xmlrpc": {
+    "node_modules/xmlrpc": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xmlrpc/-/xmlrpc-1.0.1.tgz",
-      "integrity": "sha1-QZcSWnn5mG1Ih2cVqC0Gj+8WiuM="
+      "integrity": "sha512-kgl48pCDsbUdRH95aupqupEp6qSYALohWaOJvwq9ffGxRIv2NLOVaZ2sN8GnVKmoVKm+Evm7QCxBSu+L+jPdCw==",
+      "dependencies": {
+        "sax": "0.4.x",
+        "xmlbuilder": "0.3.1"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "dependencies": {
     "grunt": "0.4.5",
     "grunt-jquery-content": "2.0.0"
+  },
+  "overrides": {
+    "graceful-fs": "^4.2.11"
   }
 }


### PR DESCRIPTION
# Motivation
As stated in https://github.com/jquery-validation/validation-content/pull/59 it would be nice to have an easy/integrated way to setup a local WordPress instance. Beside WordPress, there is also the need to manually check and/or install the `xmllint` and `xsltproc` dependencies

# Solution
This PR adds the possibility to use a [Dev Container](https://containers.dev/) for development by using a DIND (docker-in-docker) container with all the dependencies already installed.
For the first installation of the WordPress instance, a detailed instruction has been added to the README.md

The setup should be as easy as 
1. Open this repository in Visual Studio Code with Dev Containers extension installed
2. Once the Dev Container has started up: `docker-compose up`
3. Complete Wordpress installation on: `http://localhost:8080`